### PR TITLE
RDKOSS-308: Fix siginfo File Download Failure Due to Filename Length

### DIFF
--- a/meta/classes/sstate.bbclass
+++ b/meta/classes/sstate.bbclass
@@ -10,9 +10,10 @@ def generate_sstatefn(spec, hash, taskname, siginfo, d):
        return ""
     extension = ".tar.zst"
     # 8 chars reserved for siginfo
-    limit = 254 - 8
+    # 4 chars for ".tmp" extention when signinfo file is downloaded from sstate mirror using wget
+    limit = 254 - (8+4)
     if siginfo:
-        limit = 254
+        limit = 254 - 4
         extension = ".tar.zst.siginfo"
     if not hash:
         hash = "INVALID"


### PR DESCRIPTION
Reason for Change: Downloading siginfo files from the HTTP sstate mirror server fails when the original filename length is 253 characters. During this process, `wget` appends a ".tmp" extension, increasing the total length to 257 characters. This surpasses the 256-character limit, causing a "File name too long" error. Fix - Adjust logic to account for the additional 4 characters from the ".tmp" extension when generating sstate filenames to ensure successful downloads.