### PR TITLE
RDKTV-37627 : run-postinsts pkg removal fix

### DIFF
--- a/meta/lib/oe/rootfs.py
+++ b/meta/lib/oe/rootfs.py
@@ -258,7 +258,7 @@ class Rootfs(object, metaclass=ABCMeta):
         delayed_postinsts = self._get_delayed_postinsts()
         if delayed_postinsts is None:
             if os.path.exists(self.d.expand("${IMAGE_ROOTFS}${sysconfdir}/init.d/run-postinsts")) or os.path.exists(self.d.expand("${IMAGE_ROOTFS}${systemd_system_unitdir}/run-postinsts.service")):
-                self.pm.remove(["run-postinsts"])
+                self.pm.remove(["%srun-postinsts"%self.d.getVar("MLPREFIX")])
 
         image_rorfs = bb.utils.contains("IMAGE_FEATURES", "read-only-rootfs",
                                         True, False, self.d)


### PR DESCRIPTION
In the multilib.bbclass, Yocto updates all packages listed in PACKAGE_INSTALL to adjust the variant of the recipes. As a result, all packages in PACKAGE_INSTALL are updated with the MLPREFIX.

import oe.classextend
clsextend = oe.classextend.ClassExtender(variant, d)
clsextend.map_depends_variable("PACKAGE_INSTALL")

This will update PACKAGE_INSTALL with lib32-run-postinsts.

However, in the rootfs stage, Yocto tries to remove the package run-postinsts (without the MLPREFIX) after installing all packages. 

Due to the mismatch between the installed package (lib32-run-postinsts) and the one being removed (run-postinsts), the removal fails.

The proper fix should be to update the rootfs removal logic to use the correct MLPREFIX when removing such packages.