### PR TITLE
RDKOSS-372:Reverse of override-syntax-changes

### DIFF
--- a/bitbake/lib/bb/cache.py
+++ b/bitbake/lib/bb/cache.py
@@ -54,12 +54,12 @@ class RecipeInfoCommon(object):
 
     @classmethod
     def pkgvar(cls, var, packages, metadata):
-        return dict((pkg, cls.depvar("%s:%s" % (var, pkg), metadata))
+        return dict((pkg, cls.depvar("%s_%s" % (var, pkg), metadata))
                     for pkg in packages)
 
     @classmethod
     def taskvar(cls, var, tasks, metadata):
-        return dict((task, cls.getvar("%s:task-%s" % (var, task), metadata))
+        return dict((task, cls.getvar("%s_task-%s" % (var, task), metadata))
                     for task in tasks)
 
     @classmethod

--- a/bitbake/lib/bb/data_smart.py
+++ b/bitbake/lib/bb/data_smart.py
@@ -995,8 +995,6 @@ class DataSmart(MutableMapping):
         # Instead, we're careful with writes.
         data.overridedata = copy.copy(self.overridedata)
 
-        data.overridedata = copy.copy(self.overridedata)
-
         return data
 
     def expandVarref(self, variable, parents=False):

--- a/bitbake/lib/bb/siggen.py
+++ b/bitbake/lib/bb/siggen.py
@@ -245,7 +245,7 @@ class SignatureGeneratorBasic(SignatureGenerator):
         #    self.dump_sigtask(fn, task, d.getVar("STAMP"), False)
 
         for task in taskdeps:
-            d.setVar("BB_BASEHASH:task-%s" % task, self.basehash[fn + ":" + task])
+            d.setVar("BB_BASEHASH_task-%s" % task, self.basehash[fn + ":" + task])
 
     def postparsing_clean_cache(self):
         #
@@ -345,7 +345,7 @@ class SignatureGeneratorBasic(SignatureGenerator):
 
         h = hashlib.sha256(data.encode("utf-8")).hexdigest()
         self.taskhash[tid] = h
-        #d.setVar("BB_TASKHASH:task-%s" % task, taskhash[task])
+        #d.setVar("BB_TASKHASH_task-%s" % task, taskhash[task])
         return h
 
     def writeout_file_checksum_cache(self):


### PR DESCRIPTION
Reason for change: Reverse the override syntax changes in poky till all the meta layers are migrated to github. Once all the layers are moved, we should fix all the layers to use ":" instead of "_" for overrides and revert this change. This is a temporary change.