### PR TITLE
RDKOSS-679: Fix CONNECTIVITY_CHECK_URIS redirect issue

### DIFF
--- a/meta/conf/distro/include/default-distrovars.inc
+++ b/meta/conf/distro/include/default-distrovars.inc
@@ -52,4 +52,4 @@ KERNEL_IMAGETYPES ??= "${KERNEL_IMAGETYPE}"
 # fetch from the network (and warn you if not). To disable the test set
 # the variable to be empty.
 # Git example url: git://git.yoctoproject.org/yocto-firewall-test;protocol=git;rev=master;branch=master
-CONNECTIVITY_CHECK_URIS ?= "https://yoctoproject.org/connectivity.html"
+CONNECTIVITY_CHECK_URIS ?= "https://www.yoctoproject.org/connectivity.html"

--- a/meta/lib/oeqa/sdk/buildtools-cases/https.py
+++ b/meta/lib/oeqa/sdk/buildtools-cases/https.py
@@ -13,8 +13,8 @@ class HTTPTests(OESDKTestCase):
     """
 
     def test_wget(self):
-        self._run('env -i wget --debug --output-document /dev/null https://yoctoproject.org/connectivity.html')
+        self._run('env -i wget --debug --output-document /dev/null https://www.yoctoproject.org/connectivity.html')
 
     def test_python(self):
         # urlopen() returns a file-like object on success and throws an exception otherwise
-        self._run('python3 -c \'import urllib.request; urllib.request.urlopen("https://yoctoproject.org/connectivity.html")\'')
+        self._run('python3 -c \'import urllib.request; urllib.request.urlopen("https://www.yoctoproject.org/connectivity.html")\'')


### PR DESCRIPTION
Reason for the change: backport upstream fix - 6ae24cb3c61948fd82a41fa1556c90420f9a5fa1

default-distrovars.inc: Fix CONNECTIVITY_CHECK_URIS redirect issue

The default CONNECTIVITY_CHECK_URIS uses "https://yoctoproject.org/connectivity.html" which redirect to "https://www.yoctoproject.org/connectivity.html".

Some network configurations with proxies or restricted internet access don't handle HTTP redirects properly during the sanity check phase, causing build failures with:

ERROR:  OE-core's config sanity checker detected a potential misconfiguration. Either fix the cause of this error or at your own risk disable the checker (see sanity.conf). Following is the list of potential problems / advisories:

Fetcher failure for URL: 'https://yoctoproject.org/connectivity.html'. URL doesn't work.

Updated the default URL to use the final destination directly to avoid redirect-related connectivity check failures.

Also updated SDK test cases in https.py to use the corrected URL for consistency.

(From OE-Core rev: aceb2920fbdef43db7b0b698865358e288901610)



(cherry picked from commit 60cdf960a3560f391babd559737f1afb31fb2c5c)


(cherry picked from commit 6ae24cb3c61948fd82a41fa1556c90420f9a5fa1)