### PR TITLE
RDKOSS-909:pass -f to opkg-make-index to preserve user-defined fields

### DIFF
--- a/meta/lib/oe/package_manager/ipk/__init__.py
+++ b/meta/lib/oe/package_manager/ipk/__init__.py
@@ -39,7 +39,7 @@ class OpkgIndexer(Indexer):
                 if not os.path.exists(pkgs_file):
                     open(pkgs_file, "w").close()
 
-                index_cmds.add('%s --checksum md5 --checksum sha256 -r %s -p %s -m %s' %
+                index_cmds.add('%s --checksum md5 --checksum sha256 -f -r %s -p %s -m %s' %
                                   (opkg_index_cmd, pkgs_file, pkgs_file, pkgs_dir))
 
                 index_sign_files.add(pkgs_file)


### PR DESCRIPTION
Reason for change:
opkg-make-index strips non-standard IPK control fields (e.g. Source-URI, Source-Rev written by a custom bbclass) from the Packages index unless the -f (Include user-defined fields) flag is supplied.  Without -f every indexing run logs "Lost field: <fieldname>" for every custom field in every package and the fields are absent from the resulting Packages file, making them unavailable to downstream consumers.

Add -f to the opkg-make-index command in OpkgIndexer.write_index() so that user-defined fields are preserved in all Packages indexes written during do_rootfs.